### PR TITLE
Add Dark+ Default Member List theme CSS file

### DIFF
--- a/Dark+-DefaultMemberList.theme.css
+++ b/Dark+-DefaultMemberList.theme.css
@@ -1,0 +1,28 @@
+/**
+  * @name Dark+ Default Member List
+  * @author DevEvil
+  * @version Dark+5.1
+  * @description Highly customized dark and purple theme for Discord with the default member list.
+  * @authorId 468132563714703390
+  * @authorLink https://devevil.com
+  * @source https://github.com/DevEvil99/DarkPlus-Discord-Theme
+  * @website https://devevil.com
+  * @donate https://devevil.com/dnt
+  * @invite jsQ9UP7kCA
+*/
+
+@import url('https://devevil99.github.io/devevil/BetterDiscordAddons/Theme/Dark+-Defualt-Member-List/Dark+-Default-Member-List.css');
+
+:root {
+  --darkplus-bg: #212121;
+  --darkplus-bg2: #302f2f;
+  --darkplus-sec: #bb86fc;
+  --darkplus-links: #cdaef3;
+  --darkplus-home-icon: url(https://i.imgur.com/RvlNQ7k.png);
+ --watermark-filter-invert: 0%;
+  --watermark-filter-sepia: 50%;
+  --watermark-filter-saturate: 3000%;
+  --watermark-filter-hue-rotate: 210deg;
+  --watermark-filter-brightness: 70%;
+  --watermark-filter-contrast: 200%;
+}


### PR DESCRIPTION
Add a dark+ default member list file.

Also, I noticed that in the url:

[https://devevil99.github.io/devevil/BetterDiscordAddons/Theme/Dark+-Defualt-Member-List/Dark+-Default-Member-List.css
](https://devevil99.github.io/devevil/BetterDiscordAddons/Theme/Dark+-Defualt-Member-List/Dark+-Default-Member-List.css
)
The first instance of "Default" is spelled "Defualt"

Corrected:
[https://devevil99.github.io/devevil/BetterDiscordAddons/Theme/Dark+-Default-Member-List/Dark+-Default-Member-List.css](https://devevil99.github.io/devevil/BetterDiscordAddons/Theme/Dark+-Default-Member-List/Dark+-Default-Member-List.css)